### PR TITLE
build: switch to multi-stage build with Alpine

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -19,7 +19,7 @@ FROM docker.io/alpine:3.22 AS runtime
 WORKDIR /app
 
 # Install oath-toolkit-oathtool in the runtime image
-RUN apk --no-cache add oath-toolkit-oathtool
+RUN apk --no-cache add oath-toolkit-oathtool=~2.6.12
 
 # Copy the built binary from the builder stage
 COPY --from=builder /app/whale .

--- a/Containerfile
+++ b/Containerfile
@@ -1,8 +1,5 @@
 # Use Go as base image for building
-FROM docker.io/golang:1.24
-
-# Install oath-toolkit-oathtool
-RUN apt-get update && apt-get install -y oathtool && rm -rf /var/lib/apt/lists/*
+FROM docker.io/golang:1.24-alpine3.22 AS builder
 
 # Set working directory
 WORKDIR /app
@@ -15,6 +12,17 @@ RUN go mod download
 
 # Build the Go application
 RUN go build -o whale
+
+FROM docker.io/alpine:3.22 AS runtime
+
+# Set working directory
+WORKDIR /app
+
+# Install oath-toolkit-oathtool in the runtime image
+RUN apk --no-cache add oath-toolkit-oathtool
+
+# Copy the built binary from the builder stage
+COPY --from=builder /app/whale .
 
 # Expose the service port (based on your configuration)
 EXPOSE 8080


### PR DESCRIPTION
Refactor the Containerfile to use a multi-stage build. Replace the
Debian-based golang image with golang:1.24-alpine for the builder
stage, and introduce a minimal Alpine runtime stage. Install
oath-toolkit-oathtool in the runtime image using apk, and copy the
compiled binary from the builder. This reduces image size and improves
build efficiency.
