### PR TITLE
fix(auth): add timeout to login backend HTTP client

### DIFF
--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -89,7 +89,10 @@ func InitJWT() *jwt.GinJWTMiddleware {
 			}
 			req.Header.Set("Content-Type", "application/json")
 
-			client := &http.Client{}
+			// Timeout avoids the client hanging indefinitely if the backend
+			// leaves the response unfinished (e.g. an unhandled exception
+			// that never calls resp.end() on the restify side).
+			client := &http.Client{Timeout: 30 * time.Second}
 			resp, err := client.Do(req)
 			if err != nil {
 				logs.Log("[AUTH] Failed to send request to NetCTI")


### PR DESCRIPTION
## Summary

The `http.Client` used in `middleware/middleware.go` to forward `/login` requests to the legacy NetCTI backend was created with no `Timeout`. If the backend leaves the response unfinished (for example an unhandled exception path that never writes a status line and never closes the connection), the call to `client.Do(req)` will block indefinitely.

In practice this means the goroutine handling the login stays parked and the underlying TCP connection to the backend is kept open with no upper bound, in some cases for days.

All other `http.Client` instances in this repository already set a `Timeout` (see `methods/auth.go`, `methods/history.go`, `methods/voicemail.go`, `methods/proxy.go`, `store/persistence.go`); this change restores consistency by setting `Timeout: 30 * time.Second` on the login client as well.