### PR TITLE
fix(history): transcription filter must keep calls that also have a summary

### DIFF
--- a/methods/history.go
+++ b/methods/history.go
@@ -326,16 +326,11 @@ func filterHistoryRowsByArtifact(c *gin.Context, artifact string, rows []map[str
 			}
 
 			item, ok := statusMap[lookupKey]
-			if !ok || strings.TrimSpace(item.State) != "done" {
+			if !ok {
 				continue
 			}
 
-			if artifact == historyArtifactSummary && item.HasSummary {
-				filtered = append(filtered, row)
-				continue
-			}
-
-			if artifact == historyArtifactTranscription && item.HasTranscription && !item.HasSummary {
+			if historyArtifactRowMatches(artifact, item) {
 				filtered = append(filtered, row)
 			}
 		}
@@ -343,6 +338,27 @@ func filterHistoryRowsByArtifact(c *gin.Context, artifact string, rows []map[str
 		return filtered, nil
 	default:
 		return rows, nil
+	}
+}
+
+// historyArtifactRowMatches reports whether a history row carrying the given
+// summary/transcription status should be kept for the requested artifact filter.
+// The Summary and Transcription filters are allowed to overlap: a call that has
+// both a summary and a transcription matches both filters, consistent with the
+// UI where the "View transcription" action is available whenever the call has a
+// transcription regardless of an accompanying summary.
+func historyArtifactRowMatches(artifact string, item SummaryListItem) bool {
+	if strings.TrimSpace(item.State) != "done" {
+		return false
+	}
+
+	switch artifact {
+	case historyArtifactSummary:
+		return item.HasSummary
+	case historyArtifactTranscription:
+		return item.HasTranscription
+	default:
+		return false
 	}
 }
 

--- a/methods/history_test.go
+++ b/methods/history_test.go
@@ -142,3 +142,57 @@ func setupHistoryArtifactTest(t *testing.T, fetchList func([]string) ([]SummaryL
 
 	return router, cleanup
 }
+
+func TestHistoryArtifactRowMatches(t *testing.T) {
+	cases := []struct {
+		name     string
+		artifact string
+		item     SummaryListItem
+		want     bool
+	}{
+		{
+			name:     "transcription filter keeps transcription-only call",
+			artifact: historyArtifactTranscription,
+			item:     SummaryListItem{State: "done", HasTranscription: true},
+			want:     true,
+		},
+		{
+			name:     "transcription filter keeps call that also has a summary",
+			artifact: historyArtifactTranscription,
+			item:     SummaryListItem{State: "done", HasTranscription: true, HasSummary: true},
+			want:     true,
+		},
+		{
+			name:     "transcription filter drops call without transcription",
+			artifact: historyArtifactTranscription,
+			item:     SummaryListItem{State: "done", HasSummary: true},
+			want:     false,
+		},
+		{
+			name:     "summary filter keeps call with summary and transcription",
+			artifact: historyArtifactSummary,
+			item:     SummaryListItem{State: "done", HasTranscription: true, HasSummary: true},
+			want:     true,
+		},
+		{
+			name:     "summary filter drops transcription-only call",
+			artifact: historyArtifactSummary,
+			item:     SummaryListItem{State: "done", HasTranscription: true},
+			want:     false,
+		},
+		{
+			name:     "non-done state is never matched",
+			artifact: historyArtifactTranscription,
+			item:     SummaryListItem{State: "processing", HasTranscription: true},
+			want:     false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := historyArtifactRowMatches(tc.artifact, tc.item); got != tc.want {
+				t.Fatalf("historyArtifactRowMatches(%q, %+v) = %v, want %v", tc.artifact, tc.item, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem
In CTI History, the **Transcription** content filter returned (almost) no results. The server-side artifact filter excluded any row that also had a summary:

`methods/history.go`
```go
if artifact == historyArtifactTranscription && item.HasTranscription && !item.HasSummary {
```

A summary is derived from the transcription, so most transcribed calls also have a summary — the `!item.HasSummary` guard hid them all.

QA point 8 of NethServer/dev#7143.

## Fix
- `HasTranscription` and `HasSummary` are independent flags. Extract the match decision into the pure helper `historyArtifactRowMatches` and allow the Summary and Transcription filters to overlap.
- The Transcription filter now keeps any `done` call with a transcription, consistent with the UI (the *View transcription* action is shown whenever `hasSummary || hasTranscription`).
- Add unit tests covering the summary+transcription overlap and the `done`-state guard.

## Tests
`go test ./methods/` green; new `TestHistoryArtifactRowMatches` passes.

Closes NethServer/dev#8039