### PR TITLE
fix(history): correlate transcript status per-leg (uniqueid) on transfers

### DIFF
--- a/methods/history.go
+++ b/methods/history.go
@@ -346,11 +346,16 @@ func filterHistoryRowsByArtifact(c *gin.Context, artifact string, rows []map[str
 	}
 }
 
+// historySummaryLookupKey identifies a history row for transcript/summary
+// status correlation. It prefers the per-leg uniqueid so that each leg of a
+// transfer (several rows share one linkedid, one row per uniqueid) is correlated
+// to its own transcript, instead of collapsing the whole call onto a single
+// linkedid-keyed status. Falls back to linkedid when the uniqueid is absent.
 func historySummaryLookupKey(linkedID string, uniqueID string) string {
-	if linkedID != "" {
-		return linkedID
+	if uniqueID != "" {
+		return uniqueID
 	}
-	return uniqueID
+	return linkedID
 }
 
 func collectHistorySummaryLookups(rows []map[string]interface{}) []SummaryStatusLookup {

--- a/methods/history_test.go
+++ b/methods/history_test.go
@@ -22,6 +22,28 @@ import (
 	"github.com/nethesis/nethcti-middleware/store"
 )
 
+func TestHistorySummaryLookupKey_PrefersUniqueID(t *testing.T) {
+	cases := []struct {
+		name     string
+		linkedID string
+		uniqueID string
+		want     string
+	}{
+		{name: "both present prefers uniqueid (per-leg)", linkedID: "L-1", uniqueID: "U-2", want: "U-2"},
+		{name: "uniqueid only", linkedID: "", uniqueID: "U-2", want: "U-2"},
+		{name: "linkedid fallback when uniqueid missing", linkedID: "L-1", uniqueID: "", want: "L-1"},
+		{name: "both empty", linkedID: "", uniqueID: "", want: ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := historySummaryLookupKey(tc.linkedID, tc.uniqueID); got != tc.want {
+				t.Fatalf("historySummaryLookupKey(%q, %q) = %q, want %q", tc.linkedID, tc.uniqueID, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestGetFilteredHistory_ReturnsServiceUnavailableWhenTranscriptsTableIsMissing(t *testing.T) {
 	router, cleanup := setupHistoryArtifactTest(t, func([]string) ([]SummaryListItem, error) {
 		return nil, &pgconn.PgError{Code: "42P01", Message: `relation "transcripts" does not exist`}

--- a/methods/summary.go
+++ b/methods/summary.go
@@ -70,6 +70,11 @@ type SummaryListItem struct {
 	HasSummary       bool       `json:"has_summary"`
 	SrcNumber        string     `json:"src_number,omitempty"`
 	DstNumber        string     `json:"dst_number,omitempty"`
+	// DurationSeconds is the wall-clock length of this conversation segment, set by
+	// the satellite for transfer sub-legs (consultation / post-transfer) that have
+	// no CDR row of their own for every participant. Lets the UI render a real
+	// duration instead of 00:00:00. Nil when unknown.
+	DurationSeconds  *int       `json:"duration_seconds,omitempty"`
 	// Extra marks a conversation surfaced in addition to the requested history
 	// row (e.g. the consultation leg of a transfer). The frontend renders these
 	// as their own conversation rows, keyed by id (not uniqueid, which they may
@@ -1199,7 +1204,7 @@ func fetchParticipatedConversationsFromDB(linkedIDs []string, phoneNumbers []str
 
 	query := fmt.Sprintf(`
 		SELECT DISTINCT ON (uniqueid, src_number, dst_number)
-			id, uniqueid, linkedid, cleaned_transcription, raw_transcription, summary, state, src_number, dst_number, updated_at
+			id, uniqueid, linkedid, cleaned_transcription, raw_transcription, summary, state, src_number, dst_number, duration_seconds, updated_at
 		FROM transcripts
 		WHERE deleted_at IS NULL
 			AND linkedid IN (%s)
@@ -1236,10 +1241,11 @@ func fetchParticipatedConversationsFromDB(linkedIDs []string, phoneNumbers []str
 			dbState     string
 			dbSrc       sql.NullString
 			dbDst       sql.NullString
+			dbDuration  sql.NullInt64
 			dbUpdatedAt time.Time
 		)
 
-		if err := rows.Scan(&dbID, &dbUniqueID, &dbLinkedID, &dbCleaned, &dbRaw, &dbSummary, &dbState, &dbSrc, &dbDst, &dbUpdatedAt); err != nil {
+		if err := rows.Scan(&dbID, &dbUniqueID, &dbLinkedID, &dbCleaned, &dbRaw, &dbSummary, &dbState, &dbSrc, &dbDst, &dbDuration, &dbUpdatedAt); err != nil {
 			return nil, err
 		}
 
@@ -1248,7 +1254,7 @@ func fetchParticipatedConversationsFromDB(linkedIDs []string, phoneNumbers []str
 		hasSummary := dbSummary.Valid && strings.TrimSpace(dbSummary.String) != ""
 
 		updatedAt := dbUpdatedAt
-		items = append(items, SummaryListItem{
+		item := SummaryListItem{
 			ID:               dbID,
 			LinkedID:         strings.TrimSpace(dbLinkedID.String),
 			UniqueID:         dbUniqueID,
@@ -1258,7 +1264,12 @@ func fetchParticipatedConversationsFromDB(linkedIDs []string, phoneNumbers []str
 			SrcNumber:        strings.TrimSpace(dbSrc.String),
 			DstNumber:        strings.TrimSpace(dbDst.String),
 			UpdatedAt:        &updatedAt,
-		})
+		}
+		if dbDuration.Valid {
+			d := int(dbDuration.Int64)
+			item.DurationSeconds = &d
+		}
+		items = append(items, item)
 	}
 
 	if err := rows.Err(); err != nil {
@@ -1314,7 +1325,7 @@ func fetchAllConversationsByLinkedIDsFromDB(linkedIDs []string) ([]SummaryListIt
 	placeholders := buildPostgresPlaceholders(len(linkedIDs), 1)
 	query := fmt.Sprintf(`
 		SELECT DISTINCT ON (uniqueid, src_number, dst_number)
-			id, uniqueid, linkedid, cleaned_transcription, raw_transcription, summary, state, src_number, dst_number, updated_at
+			id, uniqueid, linkedid, cleaned_transcription, raw_transcription, summary, state, src_number, dst_number, duration_seconds, updated_at
 		FROM transcripts
 		WHERE deleted_at IS NULL AND linkedid IN (%s)
 		ORDER BY uniqueid, src_number, dst_number, updated_at DESC, id DESC`, placeholders)
@@ -1342,16 +1353,17 @@ func fetchAllConversationsByLinkedIDsFromDB(linkedIDs []string) ([]SummaryListIt
 			dbState     string
 			dbSrc       sql.NullString
 			dbDst       sql.NullString
+			dbDuration  sql.NullInt64
 			dbUpdatedAt time.Time
 		)
-		if err := rows.Scan(&dbID, &dbUniqueID, &dbLinkedID, &dbCleaned, &dbRaw, &dbSummary, &dbState, &dbSrc, &dbDst, &dbUpdatedAt); err != nil {
+		if err := rows.Scan(&dbID, &dbUniqueID, &dbLinkedID, &dbCleaned, &dbRaw, &dbSummary, &dbState, &dbSrc, &dbDst, &dbDuration, &dbUpdatedAt); err != nil {
 			return nil, err
 		}
 		hasTranscription := (dbCleaned.Valid && strings.TrimSpace(dbCleaned.String) != "") ||
 			(dbRaw.Valid && strings.TrimSpace(dbRaw.String) != "")
 		hasSummary := dbSummary.Valid && strings.TrimSpace(dbSummary.String) != ""
 		updatedAt := dbUpdatedAt
-		items = append(items, SummaryListItem{
+		item := SummaryListItem{
 			ID:               dbID,
 			LinkedID:         strings.TrimSpace(dbLinkedID.String),
 			UniqueID:         dbUniqueID,
@@ -1361,7 +1373,12 @@ func fetchAllConversationsByLinkedIDsFromDB(linkedIDs []string) ([]SummaryListIt
 			SrcNumber:        strings.TrimSpace(dbSrc.String),
 			DstNumber:        strings.TrimSpace(dbDst.String),
 			UpdatedAt:        &updatedAt,
-		})
+		}
+		if dbDuration.Valid {
+			d := int(dbDuration.Int64)
+			item.DurationSeconds = &d
+		}
+		items = append(items, item)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err


### PR DESCRIPTION
## Problem
QA point 5 of NethServer/dev#7143. `historySummaryLookupKey` preferred `linkedid`, so the content-filter status lookup collapsed every leg of a transfer (one row per `uniqueid`, all sharing one `linkedid`) onto a single linkedid-keyed status — giving all legs the same Summary/Transcription verdict.

## Fix
Prefer the per-leg `uniqueid` (fall back to `linkedid` when absent) so each history row correlates to its own leg's transcript. This aligns the content-filter path with `fetchParticipatedConversationsFromDB`, which already returns one row per leg, de-duped per `(uniqueid, src, dst)`.

Pairs with the per-leg persistence fix in nethesis/ns8-nethvoice#859.

## Tests
`TestHistorySummaryLookupKey_PrefersUniqueID` added; `go test ./methods/` green, `go vet` clean.

Part of NethServer/dev#8040.