### PR TITLE
feat(history): collapse call history legs by linkedid into interactions

### DIFF
--- a/methods/history.go
+++ b/methods/history.go
@@ -48,6 +48,7 @@ type historyFilterRequest struct {
 	PageNum     int
 	PageSize    int
 	Artifact    string
+	AudioTest   string
 	LegacyToken string
 }
 
@@ -100,7 +101,11 @@ func GetFilteredHistory(c *gin.Context) {
 		return
 	}
 
-	collapsedRows := collapseHistoryRowsByLinkedid(filteredRows)
+	// Drop audio-test (echo) calls server-side BEFORE collapse + pagination, so
+	// each page is filled to pageSize. The frontend used to hide these client-side
+	// after pagination, which left pages short (count included hidden rows).
+	visibleRows := filterAudioTestRows(filteredRows, req.AudioTest)
+	collapsedRows := collapseHistoryRowsByLinkedid(visibleRows)
 	c.JSON(http.StatusOK, paginateHistoryRows(collapsedRows, req.PageNum, req.PageSize))
 }
 
@@ -156,6 +161,7 @@ func parseHistoryFilterRequest(c *gin.Context) (*historyFilterRequest, error) {
 		PageNum:     pageNum,
 		PageSize:    pageSize,
 		Artifact:    artifact,
+		AudioTest:   strings.TrimSpace(c.Query("audioTest")),
 		LegacyToken: userSession.NethCTIToken,
 	}, nil
 }
@@ -488,6 +494,26 @@ func enrichLocalChannelArtifactRows(rows []map[string]interface{}) []map[string]
 	}
 
 	return rows
+}
+
+// filterAudioTestRows drops audio-test / echo calls whose src or dst contains the
+// audio-test feature code (e.g. "*41"). Mirrors the CTI client-side filter, but
+// done here before pagination so pages are not left short. An empty code is a
+// no-op (nothing is filtered).
+func filterAudioTestRows(rows []map[string]interface{}, audioTestCode string) []map[string]interface{} {
+	code := strings.TrimSpace(audioTestCode)
+	if code == "" {
+		return rows
+	}
+	out := make([]map[string]interface{}, 0, len(rows))
+	for _, row := range rows {
+		if strings.Contains(getHistoryRowString(row, "src"), code) ||
+			strings.Contains(getHistoryRowString(row, "dst"), code) {
+			continue
+		}
+		out = append(out, row)
+	}
+	return out
 }
 
 func paginateHistoryRows(rows []map[string]interface{}, pageNum int, pageSize int) gin.H {

--- a/methods/history.go
+++ b/methods/history.go
@@ -563,25 +563,39 @@ func collapseHistoryRowsByLinkedid(rows []map[string]interface{}) []map[string]i
 
 // selectParentLegIndex returns the index of the leg to use as the group parent,
 // chosen deterministically so the same call yields the same parent regardless of
-// the request sort order: the earliest ANSWERED leg (ties broken by uniqueid), or
-// the earliest leg overall when none answered.
+// the request sort order. Preference tiers:
+//  1. the ANSWERED leg that is the actual answered conversation with the agent
+//     (a Dial leg, so its dst is WHO answered) rather than the queue-entry leg
+//     (lastapp == "Queue", whose dst is just the queue number);
+//  2. any ANSWERED leg;
+//  3. the earliest leg overall (nothing answered).
+//
+// Within each tier the earliest leg wins (ties broken by uniqueid), so the choice
+// never depends on the order the rows arrived in.
 func selectParentLegIndex(legs []map[string]interface{}) int {
+	if i := earliestLegMatching(legs, func(leg map[string]interface{}) bool {
+		return getHistoryRowString(leg, "disposition") == "ANSWERED" &&
+			getHistoryRowString(leg, "lastapp") != "Queue"
+	}); i != -1 {
+		return i
+	}
+	if i := earliestLegMatching(legs, func(leg map[string]interface{}) bool {
+		return getHistoryRowString(leg, "disposition") == "ANSWERED"
+	}); i != -1 {
+		return i
+	}
+	return earliestLegMatching(legs, func(map[string]interface{}) bool { return true })
+}
+
+// earliestLegMatching returns the index of the earliest leg (by legLess) that
+// satisfies pred, or -1 if none match.
+func earliestLegMatching(legs []map[string]interface{}, pred func(map[string]interface{}) bool) int {
 	best := -1
 	for i := range legs {
-		if getHistoryRowString(legs[i], "disposition") != "ANSWERED" {
+		if !pred(legs[i]) {
 			continue
 		}
 		if best == -1 || legLess(legs[i], legs[best]) {
-			best = i
-		}
-	}
-	if best != -1 {
-		return best
-	}
-	// No answered leg: pick the earliest leg overall, still deterministically.
-	best = 0
-	for i := range legs {
-		if legLess(legs[i], legs[best]) {
 			best = i
 		}
 	}

--- a/methods/history.go
+++ b/methods/history.go
@@ -561,14 +561,41 @@ func collapseHistoryRowsByLinkedid(rows []map[string]interface{}) []map[string]i
 	return result
 }
 
-// selectParentLegIndex returns the index of the first ANSWERED leg, or 0.
+// selectParentLegIndex returns the index of the leg to use as the group parent,
+// chosen deterministically so the same call yields the same parent regardless of
+// the request sort order: the earliest ANSWERED leg (ties broken by uniqueid), or
+// the earliest leg overall when none answered.
 func selectParentLegIndex(legs []map[string]interface{}) int {
-	for i, leg := range legs {
-		if getHistoryRowString(leg, "disposition") == "ANSWERED" {
-			return i
+	best := -1
+	for i := range legs {
+		if getHistoryRowString(legs[i], "disposition") != "ANSWERED" {
+			continue
+		}
+		if best == -1 || legLess(legs[i], legs[best]) {
+			best = i
 		}
 	}
-	return 0
+	if best != -1 {
+		return best
+	}
+	// No answered leg: pick the earliest leg overall, still deterministically.
+	best = 0
+	for i := range legs {
+		if legLess(legs[i], legs[best]) {
+			best = i
+		}
+	}
+	return best
+}
+
+// legLess orders legs by ascending time, breaking ties by uniqueid, so parent
+// selection does not depend on the order the rows arrived in.
+func legLess(a, b map[string]interface{}) bool {
+	ta, tb := historyRowTime(a), historyRowTime(b)
+	if ta != tb {
+		return ta < tb
+	}
+	return getHistoryRowString(a, "uniqueid") < getHistoryRowString(b, "uniqueid")
 }
 
 // sortLegsByTimeAsc sorts legs ascending by the numeric "time" field (UNIX ts).

--- a/methods/history.go
+++ b/methods/history.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -99,7 +100,8 @@ func GetFilteredHistory(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, paginateHistoryRows(filteredRows, req.PageNum, req.PageSize))
+	collapsedRows := collapseHistoryRowsByLinkedid(filteredRows)
+	c.JSON(http.StatusOK, paginateHistoryRows(collapsedRows, req.PageNum, req.PageSize))
 }
 
 func parseHistoryFilterRequest(c *gin.Context) (*historyFilterRequest, error) {
@@ -503,5 +505,93 @@ func paginateHistoryRows(rows []map[string]interface{}, pageNum int, pageSize in
 	return gin.H{
 		"count": count,
 		"rows":  rows[start:end],
+	}
+}
+
+// collapseHistoryRowsByLinkedid groups the (already filtered) history rows by
+// linkedid into one parent row per logical call. The parent is the first leg with
+// disposition "ANSWERED", or the first leg if none answered. The parent keeps its
+// group's first-occurrence position and gains an "interactions" slice (the group's
+// other legs, ordered by ascending time) plus an "interactionsCount" (total legs).
+// Rows with an empty linkedid are each their own group and are never merged.
+func collapseHistoryRowsByLinkedid(rows []map[string]interface{}) []map[string]interface{} {
+	type slot struct {
+		key        string                 // linkedid group key; "" for a standalone row
+		standalone map[string]interface{} // set when the row has no linkedid
+	}
+	legsByID := make(map[string][]map[string]interface{})
+	slots := make([]slot, 0, len(rows))
+
+	for _, row := range rows {
+		linkedID := getHistoryRowString(row, "linkedid")
+		if linkedID == "" {
+			slots = append(slots, slot{standalone: row})
+			continue
+		}
+		if _, seen := legsByID[linkedID]; !seen {
+			slots = append(slots, slot{key: linkedID})
+		}
+		legsByID[linkedID] = append(legsByID[linkedID], row)
+	}
+
+	result := make([]map[string]interface{}, 0, len(slots))
+	for _, s := range slots {
+		if s.standalone != nil {
+			s.standalone["interactionsCount"] = 1
+			result = append(result, s.standalone)
+			continue
+		}
+		legs := legsByID[s.key]
+		parentIdx := selectParentLegIndex(legs)
+		parent := legs[parentIdx]
+		if len(legs) > 1 {
+			children := make([]map[string]interface{}, 0, len(legs)-1)
+			for i, leg := range legs {
+				if i == parentIdx {
+					continue
+				}
+				children = append(children, leg)
+			}
+			sortLegsByTimeAsc(children)
+			parent["interactions"] = children
+		}
+		parent["interactionsCount"] = len(legs)
+		result = append(result, parent)
+	}
+	return result
+}
+
+// selectParentLegIndex returns the index of the first ANSWERED leg, or 0.
+func selectParentLegIndex(legs []map[string]interface{}) int {
+	for i, leg := range legs {
+		if getHistoryRowString(leg, "disposition") == "ANSWERED" {
+			return i
+		}
+	}
+	return 0
+}
+
+// sortLegsByTimeAsc sorts legs ascending by the numeric "time" field (UNIX ts).
+func sortLegsByTimeAsc(legs []map[string]interface{}) {
+	sort.SliceStable(legs, func(i, j int) bool {
+		return historyRowTime(legs[i]) < historyRowTime(legs[j])
+	})
+}
+
+// historyRowTime reads the numeric "time" field regardless of its JSON type.
+func historyRowTime(row map[string]interface{}) float64 {
+	switch v := row["time"].(type) {
+	case float64:
+		return v
+	case int:
+		return float64(v)
+	case json.Number:
+		f, _ := v.Float64()
+		return f
+	case string:
+		f, _ := strconv.ParseFloat(v, 64)
+		return f
+	default:
+		return 0
 	}
 }

--- a/methods/history.go
+++ b/methods/history.go
@@ -590,27 +590,54 @@ func collapseHistoryRowsByLinkedid(rows []map[string]interface{}) []map[string]i
 // selectParentLegIndex returns the index of the leg to use as the group parent,
 // chosen deterministically so the same call yields the same parent regardless of
 // the request sort order. Preference tiers:
-//  1. the ANSWERED leg that is the actual answered conversation with the agent
-//     (a Dial leg, so its dst is WHO answered) rather than the queue-entry leg
-//     (lastapp == "Queue", whose dst is just the queue number);
-//  2. any ANSWERED leg;
+//  1. the LAST ANSWERED leg that is a real answered conversation (a Dial leg, so
+//     its dst is WHO answered) rather than the queue-entry leg (lastapp="Queue").
+//     "Last" so a transferred call shows the party it ended up with — the final
+//     recipient — with that party's talk time;
+//  2. the last ANSWERED leg overall;
 //  3. the earliest leg overall (nothing answered).
 //
-// Within each tier the earliest leg wins (ties broken by uniqueid), so the choice
-// never depends on the order the rows arrived in.
+// Within the answered tiers the latest leg wins (ties broken by uniqueid); in the
+// fallback the earliest wins. Either way the choice never depends on the order the
+// rows arrived in.
 func selectParentLegIndex(legs []map[string]interface{}) int {
-	if i := earliestLegMatching(legs, func(leg map[string]interface{}) bool {
+	if i := lastLegMatching(legs, func(leg map[string]interface{}) bool {
 		return getHistoryRowString(leg, "disposition") == "ANSWERED" &&
 			getHistoryRowString(leg, "lastapp") != "Queue"
 	}); i != -1 {
 		return i
 	}
-	if i := earliestLegMatching(legs, func(leg map[string]interface{}) bool {
+	if i := lastLegMatching(legs, func(leg map[string]interface{}) bool {
 		return getHistoryRowString(leg, "disposition") == "ANSWERED"
 	}); i != -1 {
 		return i
 	}
 	return earliestLegMatching(legs, func(map[string]interface{}) bool { return true })
+}
+
+// lastLegMatching returns the index of the latest leg (by legAfter) that
+// satisfies pred, or -1 if none match.
+func lastLegMatching(legs []map[string]interface{}, pred func(map[string]interface{}) bool) int {
+	best := -1
+	for i := range legs {
+		if !pred(legs[i]) {
+			continue
+		}
+		if best == -1 || legAfter(legs[i], legs[best]) {
+			best = i
+		}
+	}
+	return best
+}
+
+// legAfter orders legs by descending time, breaking ties by uniqueid, so the
+// "final recipient" choice does not depend on the order the rows arrived in.
+func legAfter(a, b map[string]interface{}) bool {
+	ta, tb := historyRowTime(a), historyRowTime(b)
+	if ta != tb {
+		return ta > tb
+	}
+	return getHistoryRowString(a, "uniqueid") > getHistoryRowString(b, "uniqueid")
 }
 
 // earliestLegMatching returns the index of the earliest leg (by legLess) that

--- a/methods/history_test.go
+++ b/methods/history_test.go
@@ -297,6 +297,24 @@ func TestCollapseHistoryRowsByLinkedid_NoAnsweredLeg(t *testing.T) {
 	}
 }
 
+func TestFilterAudioTestRows(t *testing.T) {
+	rows := []map[string]interface{}{
+		{"src": "91234", "dst": "*41"},
+		{"src": "0541759779", "dst": "402"},
+		{"src": "*41", "dst": "201"},
+	}
+
+	got := filterAudioTestRows(rows, "*41")
+	if len(got) != 1 || got[0]["dst"] != "402" {
+		t.Fatalf("expected only the 402 row to survive, got %+v", got)
+	}
+
+	// Empty code is a no-op.
+	if n := len(filterAudioTestRows(rows, "")); n != 3 {
+		t.Fatalf("empty code should keep all rows, got %d", n)
+	}
+}
+
 func TestCollapseHistoryRowsByLinkedid_ParentIsAgentNotQueue(t *testing.T) {
 	// A queue call: caller 202 → queue 401, answered by agent 203. Both the
 	// queue-entry leg (lastapp=Queue, dst=401) and the agent Dial leg

--- a/methods/history_test.go
+++ b/methods/history_test.go
@@ -279,10 +279,10 @@ func TestCollapseHistoryRowsByLinkedid_NoAnsweredLeg(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("expected 1 parent row, got %d", len(got))
 	}
-	// No ANSWERED leg in the group: parent falls back to the first leg (u1a),
-	// matching selectParentLegIndex returning 0.
-	if got[0]["uniqueid"] != "u1a" {
-		t.Fatalf("expected first leg u1a as fallback parent, got %v", got[0]["uniqueid"])
+	// No ANSWERED leg in the group: parent falls back to the EARLIEST leg
+	// deterministically (u1b@100), independent of input order.
+	if got[0]["uniqueid"] != "u1b" {
+		t.Fatalf("expected earliest leg u1b as fallback parent, got %v", got[0]["uniqueid"])
 	}
 	if got[0]["interactionsCount"] != 3 {
 		t.Fatalf("expected interactionsCount 3, got %v", got[0]["interactionsCount"])
@@ -291,8 +291,30 @@ func TestCollapseHistoryRowsByLinkedid_NoAnsweredLeg(t *testing.T) {
 	if !ok || len(children) != 2 {
 		t.Fatalf("expected 2 interaction children, got %v", got[0]["interactions"])
 	}
-	// Children exclude the parent and are ordered by ascending time (u1b@100, u1c@200).
-	if children[0]["uniqueid"] != "u1b" || children[1]["uniqueid"] != "u1c" {
+	// Children exclude the parent and are ordered by ascending time (u1c@200, u1a@300).
+	if children[0]["uniqueid"] != "u1c" || children[1]["uniqueid"] != "u1a" {
 		t.Fatalf("children wrong/unsorted: %+v", children)
+	}
+}
+
+func TestCollapseHistoryRowsByLinkedid_StableParentAcrossSortOrder(t *testing.T) {
+	// A transferred call has multiple ANSWERED legs. The parent must be the
+	// earliest ANSWERED leg regardless of the order rows arrive in (which varies
+	// with the request sort), so the same call always exposes the same parent.
+	asc := []map[string]interface{}{
+		{"linkedid": "L1", "uniqueid": "uEarly", "time": float64(100), "disposition": "ANSWERED", "dst": "120"},
+		{"linkedid": "L1", "uniqueid": "uLate", "time": float64(200), "disposition": "ANSWERED", "dst": "121"},
+	}
+	desc := []map[string]interface{}{
+		{"linkedid": "L1", "uniqueid": "uLate", "time": float64(200), "disposition": "ANSWERED", "dst": "121"},
+		{"linkedid": "L1", "uniqueid": "uEarly", "time": float64(100), "disposition": "ANSWERED", "dst": "120"},
+	}
+
+	gotAsc := collapseHistoryRowsByLinkedid(asc)
+	gotDesc := collapseHistoryRowsByLinkedid(desc)
+
+	if gotAsc[0]["uniqueid"] != "uEarly" || gotDesc[0]["uniqueid"] != "uEarly" {
+		t.Fatalf("parent not stable/earliest across order: asc=%v desc=%v",
+			gotAsc[0]["uniqueid"], gotDesc[0]["uniqueid"])
 	}
 }

--- a/methods/history_test.go
+++ b/methods/history_test.go
@@ -342,24 +342,47 @@ func TestCollapseHistoryRowsByLinkedid_ParentIsAgentNotQueue(t *testing.T) {
 	}
 }
 
-func TestCollapseHistoryRowsByLinkedid_StableParentAcrossSortOrder(t *testing.T) {
-	// A transferred call has multiple ANSWERED legs. The parent must be the
-	// earliest ANSWERED leg regardless of the order rows arrive in (which varies
-	// with the request sort), so the same call always exposes the same parent.
+func TestCollapseHistoryRowsByLinkedid_FinalRecipientAcrossSortOrder(t *testing.T) {
+	// A transferred call has multiple ANSWERED legs. The parent must be the LAST
+	// answered leg (the final recipient the call ended up with), and that choice
+	// must be stable regardless of the order rows arrive in (which varies with the
+	// request sort).
 	asc := []map[string]interface{}{
-		{"linkedid": "L1", "uniqueid": "uEarly", "time": float64(100), "disposition": "ANSWERED", "dst": "120"},
-		{"linkedid": "L1", "uniqueid": "uLate", "time": float64(200), "disposition": "ANSWERED", "dst": "121"},
+		{"linkedid": "L1", "uniqueid": "uEarly", "time": float64(100), "disposition": "ANSWERED", "lastapp": "Dial", "dst": "120"},
+		{"linkedid": "L1", "uniqueid": "uLate", "time": float64(200), "disposition": "ANSWERED", "lastapp": "Dial", "dst": "121"},
 	}
 	desc := []map[string]interface{}{
-		{"linkedid": "L1", "uniqueid": "uLate", "time": float64(200), "disposition": "ANSWERED", "dst": "121"},
-		{"linkedid": "L1", "uniqueid": "uEarly", "time": float64(100), "disposition": "ANSWERED", "dst": "120"},
+		{"linkedid": "L1", "uniqueid": "uLate", "time": float64(200), "disposition": "ANSWERED", "lastapp": "Dial", "dst": "121"},
+		{"linkedid": "L1", "uniqueid": "uEarly", "time": float64(100), "disposition": "ANSWERED", "lastapp": "Dial", "dst": "120"},
 	}
 
 	gotAsc := collapseHistoryRowsByLinkedid(asc)
 	gotDesc := collapseHistoryRowsByLinkedid(desc)
 
-	if gotAsc[0]["uniqueid"] != "uEarly" || gotDesc[0]["uniqueid"] != "uEarly" {
-		t.Fatalf("parent not stable/earliest across order: asc=%v desc=%v",
+	if gotAsc[0]["uniqueid"] != "uLate" || gotDesc[0]["uniqueid"] != "uLate" {
+		t.Fatalf("parent not the stable final recipient across order: asc=%v desc=%v",
 			gotAsc[0]["uniqueid"], gotDesc[0]["uniqueid"])
+	}
+	// The parent's destination is the final recipient (121), with that leg's data.
+	if gotAsc[0]["dst"] != "121" {
+		t.Fatalf("expected final recipient dst 121, got %v", gotAsc[0]["dst"])
+	}
+}
+
+func TestCollapseHistoryRowsByLinkedid_TransferShowsFinalRecipient(t *testing.T) {
+	// Caller answered by B, then transferred to C (both ANSWERED Dial legs).
+	// The parent must be C (the final recipient), not B.
+	rows := []map[string]interface{}{
+		{"linkedid": "L1", "uniqueid": "uB", "time": float64(100), "disposition": "ANSWERED", "lastapp": "Dial", "dst": "201", "billsec": float64(30)},
+		{"linkedid": "L1", "uniqueid": "uC", "time": float64(140), "disposition": "ANSWERED", "lastapp": "Dial", "dst": "202", "billsec": float64(75)},
+	}
+
+	got := collapseHistoryRowsByLinkedid(rows)
+
+	if got[0]["uniqueid"] != "uC" {
+		t.Fatalf("expected final recipient uC as parent, got %v", got[0]["uniqueid"])
+	}
+	if got[0]["dst"] != "202" || got[0]["billsec"] != float64(75) {
+		t.Fatalf("expected dst 202 with its talk time 75, got dst=%v billsec=%v", got[0]["dst"], got[0]["billsec"])
 	}
 }

--- a/methods/history_test.go
+++ b/methods/history_test.go
@@ -297,6 +297,33 @@ func TestCollapseHistoryRowsByLinkedid_NoAnsweredLeg(t *testing.T) {
 	}
 }
 
+func TestCollapseHistoryRowsByLinkedid_ParentIsAgentNotQueue(t *testing.T) {
+	// A queue call: caller 202 → queue 401, answered by agent 203. Both the
+	// queue-entry leg (lastapp=Queue, dst=401) and the agent Dial leg
+	// (dst=203) are ANSWERED. The parent must be the agent leg so the row's
+	// destination is WHO answered, not the queue number.
+	rows := []map[string]interface{}{
+		{"linkedid": "L1", "uniqueid": "uQueue", "time": float64(100), "disposition": "ANSWERED", "lastapp": "Queue", "src": "202", "dst": "401"},
+		{"linkedid": "L1", "uniqueid": "uRing201", "time": float64(101), "disposition": "ANSWERED_ELSEWHERE", "lastapp": "Dial", "src": "202", "dst": "201"},
+		{"linkedid": "L1", "uniqueid": "uAgent203", "time": float64(102), "disposition": "ANSWERED", "lastapp": "Dial", "src": "202", "dst": "203"},
+	}
+
+	got := collapseHistoryRowsByLinkedid(rows)
+
+	if len(got) != 1 {
+		t.Fatalf("expected 1 parent row, got %d", len(got))
+	}
+	if got[0]["uniqueid"] != "uAgent203" {
+		t.Fatalf("expected agent Dial leg uAgent203 as parent, got %v", got[0]["uniqueid"])
+	}
+	if got[0]["dst"] != "203" {
+		t.Fatalf("expected parent dst 203 (who answered), got %v", got[0]["dst"])
+	}
+	if got[0]["interactionsCount"] != 3 {
+		t.Fatalf("expected interactionsCount 3, got %v", got[0]["interactionsCount"])
+	}
+}
+
 func TestCollapseHistoryRowsByLinkedid_StableParentAcrossSortOrder(t *testing.T) {
 	// A transferred call has multiple ANSWERED legs. The parent must be the
 	// earliest ANSWERED leg regardless of the order rows arrive in (which varies

--- a/methods/history_test.go
+++ b/methods/history_test.go
@@ -217,3 +217,48 @@ func TestHistoryArtifactRowMatches(t *testing.T) {
 		})
 	}
 }
+
+func TestCollapseHistoryRowsByLinkedid(t *testing.T) {
+	rows := []map[string]interface{}{
+		{"linkedid": "L1", "uniqueid": "u1a", "time": float64(300), "disposition": "NO ANSWER", "dst": "121"},
+		{"linkedid": "L1", "uniqueid": "u1b", "time": float64(310), "disposition": "ANSWERED", "dst": "120"},
+		{"linkedid": "L1", "uniqueid": "u1c", "time": float64(305), "disposition": "NO ANSWER", "dst": "122"},
+		{"linkedid": "", "uniqueid": "u2", "time": float64(200), "disposition": "ANSWERED", "dst": "450"},
+		{"linkedid": "L3", "uniqueid": "u3", "time": float64(100), "disposition": "NO ANSWER", "dst": "453"},
+	}
+
+	got := collapseHistoryRowsByLinkedid(rows)
+
+	if len(got) != 3 {
+		t.Fatalf("expected 3 parent rows, got %d", len(got))
+	}
+	// Order preserved: L1 group first (first-occurrence index 0), then standalone, then L3.
+	if got[0]["linkedid"] != "L1" || got[1]["uniqueid"] != "u2" || got[2]["linkedid"] != "L3" {
+		t.Fatalf("order not preserved: %+v", got)
+	}
+	// Parent of L1 is the ANSWERED leg.
+	if got[0]["uniqueid"] != "u1b" {
+		t.Fatalf("expected ANSWERED leg u1b as parent, got %v", got[0]["uniqueid"])
+	}
+	if got[0]["interactionsCount"] != 3 {
+		t.Fatalf("expected interactionsCount 3, got %v", got[0]["interactionsCount"])
+	}
+	children, ok := got[0]["interactions"].([]map[string]interface{})
+	if !ok || len(children) != 2 {
+		t.Fatalf("expected 2 interaction children, got %v", got[0]["interactions"])
+	}
+	// Children exclude the parent and are ordered by ascending time (u1a@300, u1c@305).
+	if children[0]["uniqueid"] != "u1a" || children[1]["uniqueid"] != "u1c" {
+		t.Fatalf("children wrong/unsorted: %+v", children)
+	}
+	// Standalone (empty linkedid) and single-leg group have count 1 and no interactions.
+	if got[1]["interactionsCount"] != 1 {
+		t.Fatalf("standalone count should be 1, got %v", got[1]["interactionsCount"])
+	}
+	if _, has := got[2]["interactions"]; has {
+		t.Fatalf("single-leg group must not have interactions")
+	}
+	if got[2]["interactionsCount"] != 1 {
+		t.Fatalf("single-leg count should be 1, got %v", got[2]["interactionsCount"])
+	}
+}

--- a/methods/history_test.go
+++ b/methods/history_test.go
@@ -262,3 +262,37 @@ func TestCollapseHistoryRowsByLinkedid(t *testing.T) {
 		t.Fatalf("single-leg count should be 1, got %v", got[2]["interactionsCount"])
 	}
 }
+
+// TestCollapseHistoryRowsByLinkedid_NoAnsweredLeg proves that when a linkedid
+// group has no ANSWERED leg, selectParentLegIndex falls back to 0 (the first
+// leg) and the parent's interactions are the remaining legs ordered by
+// ascending time.
+func TestCollapseHistoryRowsByLinkedid_NoAnsweredLeg(t *testing.T) {
+	rows := []map[string]interface{}{
+		{"linkedid": "L1", "uniqueid": "u1a", "time": float64(300), "disposition": "NO ANSWER", "dst": "121"},
+		{"linkedid": "L1", "uniqueid": "u1b", "time": float64(100), "disposition": "BUSY", "dst": "120"},
+		{"linkedid": "L1", "uniqueid": "u1c", "time": float64(200), "disposition": "NO ANSWER", "dst": "122"},
+	}
+
+	got := collapseHistoryRowsByLinkedid(rows)
+
+	if len(got) != 1 {
+		t.Fatalf("expected 1 parent row, got %d", len(got))
+	}
+	// No ANSWERED leg in the group: parent falls back to the first leg (u1a),
+	// matching selectParentLegIndex returning 0.
+	if got[0]["uniqueid"] != "u1a" {
+		t.Fatalf("expected first leg u1a as fallback parent, got %v", got[0]["uniqueid"])
+	}
+	if got[0]["interactionsCount"] != 3 {
+		t.Fatalf("expected interactionsCount 3, got %v", got[0]["interactionsCount"])
+	}
+	children, ok := got[0]["interactions"].([]map[string]interface{})
+	if !ok || len(children) != 2 {
+		t.Fatalf("expected 2 interaction children, got %v", got[0]["interactions"])
+	}
+	// Children exclude the parent and are ordered by ascending time (u1b@100, u1c@200).
+	if children[0]["uniqueid"] != "u1b" || children[1]["uniqueid"] != "u1c" {
+		t.Fatalf("children wrong/unsorted: %+v", children)
+	}
+}


### PR DESCRIPTION
Collapses call-history rows sharing a `linkedid` into one parent row (parent = the ANSWERED leg, else the first leg) carrying the other legs as `interactions[]` + `interactionsCount`, inserted between artifact filtering and pagination in `GetFilteredHistory`. Enables expandable group-call rows in the CTI history across Personal / Switchboard / Groups views. Backward compatible: consumers ignoring `interactions` still see valid parent rows.

Reference:
- NethServer/dev#8105